### PR TITLE
Fix a bug on build dependencies

### DIFF
--- a/test/test_rosuds/CMakeLists.txt
+++ b/test/test_rosuds/CMakeLists.txt
@@ -15,6 +15,7 @@ catkin_package(CATKIN_DEPENDS message_runtime std_msgs)
 macro(test_rosuds_build T)
   add_executable(${T}_uds ${T}/${T}.cpp)
   target_link_libraries(${T}_uds ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  add_dependencies(${T}_uds test_rosuds_gencpp)
 endmacro()
 
 foreach(dir


### PR DESCRIPTION
While using catkin_make or catkin_make_isolated to compile, no problem.

But if enter build/test_rosuds and build, build is failed since TwoLnts.srv doesn't generate corresponding .h file. We need add target dependencies.
This patch is to fix this problem. 